### PR TITLE
Request layers from github repo

### DIFF
--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -183,7 +183,10 @@ class pytri:
 
         """
         if layer_js.startswith("http"):
-            raise NotImplementedError("Cannot accept layers over HTTP yet.")
+            fetch_url = layer_js
+            layer_js = requests.get(fetch_url).text
+            print(layer_js)
+            #raise NotImplementedError("Cannot accept layers over HTTP yet.")
 
         _js = layer_js
 
@@ -198,6 +201,7 @@ class pytri:
             _js_layer_name = re.match(
                 r"[\s\S]*class (\w+) extends .*Layer[\s\S]*", _js
             )[1]
+            print(_js_layer_name)
         except TypeError as _:
             raise ValueError(
                 "layer_js must include a class that extends Layer."
@@ -206,6 +210,7 @@ class pytri:
         _js += "V['{}'].addLayer('{}', new {}({}))".format(
             self.uid, name, _js_layer_name, json.dumps(params)
         )
+        print(json.dumps(params))
 
         display(Javascript(_js))
 

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -152,6 +152,22 @@ class pytri:
         with open(file, 'r') as fh:
             _js = fh.read().strip()
         return _js
+    
+    def _fetch_layer_github(self, fname: str) -> str:
+        """
+        Fetch a layer file from the iscoe/substrate-layers repo.
+
+        Arguments:
+            fname (str)
+        
+        Returns:
+            str JS
+        """
+        fetch_url = "https://raw.githubusercontent.com/iscoe/substrate-layers/add-layers/layers/"
+        # Substrate-Layers repo, add-layers branch: https://raw.githubusercontent.com/iscoe/substrate-layers/add-layers/
+        full_url = fetch_url + fname
+        _js = requests.get(full_url).text
+        return(_js)
 
     def add_layer(self, layer_js: str, params: dict = None, name: str = None) -> str:
         """
@@ -234,7 +250,8 @@ class pytri:
         if isinstance(data, np.ndarray):
             data = data.tolist()
 
-        _js = self._fetch_layer_file("ScatterLayer.js")
+        #_js = self._fetch_layer_file("ScatterLayer.js")
+        _js = self._fetch_layer_github("ScatterLayer.js")
         return self.add_layer(_js, {
             "data": data,
             "radius": r,
@@ -257,7 +274,8 @@ class pytri:
         if isinstance(data, nx.Graph):
             data = json_graph.node_link_data(data)
 
-        _js = self._fetch_layer_file("GraphLayer.js")
+        #_js = self._fetch_layer_file("GraphLayer.js")
+        _js = self._fetch_layer_github("GraphLayer.js")
         return self.add_layer(_js, {
             "data": data,
             "radius": r,
@@ -280,7 +298,8 @@ class pytri:
         if isinstance(data, np.ndarray):
             data = data.tolist()
 
-        _js = self._fetch_layer_file("FibersLayer.js")
+        #_js = self._fetch_layer_file("FibersLayer.js")
+        _js = self._fetch_layer_github("FibersLayer.js")
         return self.add_layer(_js, {
             "data": data,
             "colors": c,

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -163,8 +163,8 @@ class pytri:
         Returns:
             str JS
         """
-        fetch_url = "https://raw.githubusercontent.com/iscoe/substrate-layers/add-layers/layers/"
-        # Substrate-Layers repo, add-layers branch: https://raw.githubusercontent.com/iscoe/substrate-layers/add-layers/
+        fetch_url = "https://raw.githubusercontent.com/iscoe/substrate-layers/layers/"
+        # Substrate-Layers repo, layers dir: https://raw.githubusercontent.com/iscoe/substrate-layers/layers/
         full_url = fetch_url + fname
         _js = requests.get(full_url).text
         return(_js)

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -152,22 +152,22 @@ class pytri:
         with open(file, 'r') as fh:
             _js = fh.read().strip()
         return _js
-    
+
     def _fetch_layer_github(self, fname: str) -> str:
         """
         Fetch a layer file from the iscoe/substrate-layers repo.
 
         Arguments:
             fname (str)
-        
+
         Returns:
             str JS
         """
+        # Substrate-Layers repo, layers dir:
         fetch_url = "https://raw.githubusercontent.com/iscoe/substrate-layers/layers/"
-        # Substrate-Layers repo, layers dir: https://raw.githubusercontent.com/iscoe/substrate-layers/layers/
         full_url = fetch_url + fname
         _js = requests.get(full_url).text
-        return(_js)
+        return _js
 
     def add_layer(self, layer_js: str, params: dict = None, name: str = None) -> str:
         """

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -250,8 +250,8 @@ class pytri:
         if isinstance(data, np.ndarray):
             data = data.tolist()
 
-        #_js = self._fetch_layer_file("ScatterLayer.js")
-        _js = self._fetch_layer_github("ScatterLayer.js")
+        _js = self._fetch_layer_file("ScatterLayer.js")
+        #_js = self._fetch_layer_github("ScatterLayer.js")
         return self.add_layer(_js, {
             "data": data,
             "radius": r,
@@ -274,8 +274,8 @@ class pytri:
         if isinstance(data, nx.Graph):
             data = json_graph.node_link_data(data)
 
-        #_js = self._fetch_layer_file("GraphLayer.js")
-        _js = self._fetch_layer_github("GraphLayer.js")
+        _js = self._fetch_layer_file("GraphLayer.js")
+        #_js = self._fetch_layer_github("GraphLayer.js")
         return self.add_layer(_js, {
             "data": data,
             "radius": r,
@@ -298,8 +298,8 @@ class pytri:
         if isinstance(data, np.ndarray):
             data = data.tolist()
 
-        #_js = self._fetch_layer_file("FibersLayer.js")
-        _js = self._fetch_layer_github("FibersLayer.js")
+        _js = self._fetch_layer_file("FibersLayer.js")
+        #_js = self._fetch_layer_github("FibersLayer.js")
         return self.add_layer(_js, {
             "data": data,
             "colors": c,


### PR DESCRIPTION
Added support for requesting non-local javascript layer files from `iscoe/substrate-layers/layers` in `_fetch_layer_github()`. 
Call currently commented out from scatter, graph, and fiber functions in favor of having the js layers for these functions live locally.