### PR TITLE
Rotate imlayer

### DIFF
--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -248,6 +248,7 @@ class pytri:
             self,
             data,
             position={"x": 0, "y": 0, "z": 0},
+            rotation={"x": 0, "y": 0, "z": 0},
             scale=10.,
             name=None
     ) -> str:
@@ -295,6 +296,7 @@ class pytri:
             "width": scale*width/height,
             "height": scale,
             "position": position,
+            "rotation": rotation
         }, name=name)
 
     def scatter(self, data, r=0.15, c=0x00babe, name=None) -> str:

--- a/pytri/js/ImageLayer.js
+++ b/pytri/js/ImageLayer.js
@@ -5,6 +5,7 @@ class ImageLayer extends Layer {
         this.width = opts.width;
         this.height = opts.height;
         this.position = opts.position;
+        this.rotation = opts.rotation;
     }
 
     requestInit(scene) {
@@ -27,6 +28,12 @@ class ImageLayer extends Layer {
             0, 0, 0, 1
         );
         plane.rotation.setFromRotationMatrix(rotationMatrix);
+        plane.rotation.set(
+            self.rotation["x"],
+            self.rotation["y"],
+            self.rotation["z"]
+        )
+        console.log("edited")
         plane.position.set(
             self.position["x"],
             self.position["y"],

--- a/pytri/js/ImageLayer.js
+++ b/pytri/js/ImageLayer.js
@@ -28,12 +28,12 @@ class ImageLayer extends Layer {
             0, 0, 0, 1
         );
         plane.rotation.setFromRotationMatrix(rotationMatrix);
+        console.log(self.rotation)
         plane.rotation.set(
             self.rotation["x"],
             self.rotation["y"],
             self.rotation["z"]
         )
-        console.log("edited")
         plane.position.set(
             self.position["x"],
             self.position["y"],


### PR DESCRIPTION
Added capabilities to rotate imshow layer relative to the default x-z plane.

I believe I may have broken my environment... this feature was working when I tested last night, but need confirmation from someone who knows their environment is stable. Although last night rotation was working perfectly, now when I add in rotation functions no images render, and no imshow layer is added to the pytri instance.