### PR TITLE
Aspect ratio

### DIFF
--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -247,7 +247,8 @@ class pytri:
     def imshow(
             self,
             data,
-            position={"x": 0, "y": 0, "z": 0},
+            position=None,
+            rotation=None,
             scale=10.,
             aspect_ratio=None,
             name=None
@@ -318,6 +319,7 @@ class pytri:
             "width": width,
             "height": height,
             "position": position,
+            "rotation": rotation
         }, name=name)
 
     def scatter(self, data, r=0.15, c=0x00babe, name=None) -> str:

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -249,6 +249,7 @@ class pytri:
             data,
             position={"x": 0, "y": 0, "z": 0},
             scale=10.,
+            aspect_ratio=None,
             name=None
     ) -> str:
         """
@@ -290,10 +291,32 @@ class pytri:
         width = data.shape[1]
         height = data.shape[0]
 
+        if aspect_ratio is None:
+            ar = float(width / height)
+        else:
+            ar = float(aspect_ratio[0]/aspect_ratio[1])
+
+        if ar < 1:
+            width = width * ar
+        elif ar > 1:
+            height = height * ar
+
+        if width < scale:
+            width = width * scale
+            height = height * scale
+        elif width > scale:
+            width = width / scale
+            height = height / scale
+            
+        if position is None:
+            position = {"x": 0, "y": 0, "z": 0}
+        if rotation is None:
+            rotation = {"x": 0, "y": 0, "z": 0}
+
         return self.add_layer(_js, {
             "dataURI": data_uri,
-            "width": scale*width/height,
-            "height": scale,
+            "width": width,
+            "height": height,
             "position": position,
         }, name=name)
 

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -250,7 +250,7 @@ class pytri:
             position=None,
             rotation=None,
             scale=10.,
-            aspect_ratio=None,
+            square=False,
             name=None
     ) -> str:
         """
@@ -292,21 +292,19 @@ class pytri:
         width = data.shape[1]
         height = data.shape[0]
 
-        if aspect_ratio is None:
+        if square == True:
             ar = float(width / height)
-        else:
-            ar = float(aspect_ratio[0]/aspect_ratio[1])
-
-        if ar < 1:
-            width = width * ar
-        elif ar > 1:
-            height = height * ar
-
+            if ar < 1:
+                width = width * ar
+            elif ar > 1:
+                height = height * ar   
         if width < scale:
             width = width * scale
-            height = height * scale
         elif width > scale:
             width = width / scale
+        if height < scale:
+            height = height * scale
+        elif height > scale:
             height = height / scale
             
         if position is None:

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -292,12 +292,12 @@ class pytri:
         width = data.shape[1]
         height = data.shape[0]
 
-        if square == True:
+        if square is True:
             ar = float(width / height)
             if ar < 1:
                 width = width * ar
             elif ar > 1:
-                height = height * ar   
+                height = height * ar
         if width < scale:
             width = width * scale
         elif width > scale:
@@ -306,7 +306,7 @@ class pytri:
             height = height * scale
         elif height > scale:
             height = height / scale
-            
+
         if position is None:
             position = {"x": 0, "y": 0, "z": 0}
         if rotation is None:

--- a/pytri/js/ImageLayer.js
+++ b/pytri/js/ImageLayer.js
@@ -5,6 +5,7 @@ class ImageLayer extends Layer {
         this.width = opts.width;
         this.height = opts.height;
         this.position = opts.position;
+        this.rotation = opts.rotation;
     }
 
     requestInit(scene) {
@@ -29,6 +30,11 @@ class ImageLayer extends Layer {
             0, 0, 0, 1
         );
         plane.rotation.setFromRotationMatrix(rotationMatrix);
+        plane.rotation.set(
+            self.rotation["x"],
+            self.rotation["y"],
+            self.rotation["z"]
+        )
         plane.position.set(
             self.position["x"],
             self.position["y"],


### PR DESCRIPTION
Added support to specify whether an image should be rendered square or according to natural aspect ratio. For anisotropic EM data, for instance, we should specify that we would like it rendered square. Other users may want the natural aspect ratio.