### PR TITLE
Enable opacity setting on mesh

### DIFF
--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -407,7 +407,11 @@ class pytri:
             "alpha": alpha
         }, name=name)
 
-    def mesh(self, data, name=None) -> str:
+    def mesh(
+            self,
+            data,
+            opacity=None,
+            name=None) -> str:
         """
         Add a mesh to the scene. Currently only supports OBJ.
 
@@ -424,6 +428,13 @@ class pytri:
         ))
 
         _js = self._fetch_layer_file("MeshLayer.js")
-        return self.add_layer(_js, {
-            "data": data
-        }, name=name)
+        props = dict()
+        props["data"] = data
+        if opacity is not None:
+            props["opacity"] = opacity
+
+        return self.add_layer(
+                _js,
+                props,
+                name=name)
+

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -434,7 +434,6 @@ class pytri:
             props["opacity"] = opacity
 
         return self.add_layer(
-                _js,
-                props,
-                name=name)
-
+            _js,
+            props,
+            name=name)

--- a/pytri/js/MeshLayer.js
+++ b/pytri/js/MeshLayer.js
@@ -2,19 +2,29 @@ class MeshLayer extends Layer {
     constructor(props) {
         super(props);
         this.data = props.data;
-        this._material = props.material;
+        this.opacity = props.opacity;
     }
 
     requestInit(scene) {
         let self = this;
         self.needsUpdate = true;
 
+        if (self.opacity) {
+            self._material = new window.THREE.MeshNormalMaterial({
+                opacity: self.opacity,
+                side: window.THREE.DoubleSide,
+                transparent: true
+            });
+        } else {
+            self._material = new window.THREE.MeshNormalMaterial({
+                side: window.THREE.DoubleSide,
+            });
+        }
+
         let mesh = new window.THREE.OBJLoader().parse(self.data);
         self._meshGeometry = new window.THREE.Mesh(
             new window.THREE.Geometry().fromBufferGeometry(mesh.children[0].geometry),
-            new window.THREE.MeshNormalMaterial({
-                side: window.THREE.DoubleSide
-            })
+            self._material
         );
         self.children = [self._meshGeometry];
 


### PR DESCRIPTION
Add optional parameter to props to set the opacity on a mesh.