### PR TITLE
reimplement pytri#graph for scalability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-- **0.2.1**
+- **0.4.0**
+    - Reimplement graphs for scalability (@hpcowley)
+- **0.3.0**
     - Change image planes to render double-sided (@hpcowley)
 - **0.2.0** (January 22, 2018)
     - Fix coloring of edges/nodes in `pytri#graph` and `pytri#large_graph` (@mlw214)

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -354,8 +354,8 @@ class pytri:
         }, name=name)
 
     def graph(self, data, radius: Union[float, Sequence[float]] = 20,
-              ind_node_color: dict = None,
-              all_node_color: Union[float, Sequence[float]] = 0xbabe00,
+              nc: dict = None,
+              all_nc: Union[float, Sequence[float]] = 0xbabe00,
               link_color: Union[float, Sequence[float]] = 0x00babe, name: str = None) -> str:
         """
         Add a graph to the visualizer.
@@ -363,8 +363,8 @@ class pytri:
         Arguments:
             data (networkx.Graph)
             radius (float | list)
-            ind_node_color (dict | {note_category: {value: color}})
-            all_node_color (float | list)
+            nc (dict | {note_category: {value: color}})
+            all_nc (float | list)
             link_color (float | list)
             name (str)
 
@@ -380,8 +380,8 @@ class pytri:
         return self.add_layer(_js, {
             "graph": data,
             "radius": radius,
-            "allNodeColor": all_node_color,
-            "nodeColors": ind_node_color,
+            "allNodeColor": all_nc,
+            "nodeColors": nc,
             "linkColor": link_color,
         }, name=name)
 

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -386,35 +386,6 @@ class pytri:
         }, name=name)
 
 
-    def large_graph(self, data, radius: Union[float, Sequence[float]] = 2,
-                    node_color: Union[float, Sequence[float]] = 0xbabe00,
-                    link_color: Union[float, Sequence[float]] = 0x00babe,
-                    name: str = None) -> str:
-        """
-        Add a large graph to the visualizer using the GPU particle system.
-
-        Arguments:
-            data (networkx.graph)
-            radius (float | list)
-            node_color (float | list)
-            link_color (float | list)
-            name (str)
-
-        Returns:
-            str: name of the layer.
-        """
-        if isinstance(data, nx.Graph):
-            data = json_graph.node_link_data(data)
-
-        _js = self._fetch_layer_file("LargeGraphLayer.js")
-        return self.add_layer(_js, {
-            "graph": data,
-            "nodeSize": radius,
-            "nodeColor": node_color,
-            "linkColor": link_color,
-        }, name=name)
-
-
     def fibers(self, data, c=0xbabe00, alpha=0.5, name=None) -> str:
         """
         Add a fiber group to the visualizer.

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -75,9 +75,6 @@ class pytri:
         self.layer_types = set()
         self.layers = set()
 
-        glow_tex = "./glow.png"
-        perlin_tex = "./perlin-512.png"
-
         display(HTML(
             "<div id='pytri-target-decoy'></div>" +
             "<script>{}</script>".format(self.js) +
@@ -372,7 +369,6 @@ class pytri:
             str: name of the layer
 
         """
-        from PIL import Image
         if isinstance(data, nx.Graph):
             data = json_graph.node_link_data(data)
         _js = self._fetch_layer_file("ColorGraphLayer.js")

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -75,10 +75,13 @@ class pytri:
         self.layer_types = set()
         self.layers = set()
 
+        glow_tex = "./glow.png"
+        perlin_tex = "./perlin-512.png"
+
         display(HTML(
             "<div id='pytri-target-decoy'></div>" +
             "<script>{}</script>".format(self.js) +
-            "<script>{}</script>".format(self.gpu_js) +
+            "<script>{}</script>".format(self.gpu_js)+
             """
             <script>
             window.V = window.V || {}
@@ -350,8 +353,9 @@ class pytri:
             "colors": c
         }, name=name)
 
-    def graph(self, data, radius: Union[float, Sequence[float]] = 0.15,
-              node_color: Union[float, Sequence[float]] = 0xbabe00,
+    def graph(self, data, radius: Union[float, Sequence[float]] = 20,
+              ind_node_color: dict = None,
+              all_node_color: Union[float, Sequence[float]] = 0xbabe00,
               link_color: Union[float, Sequence[float]] = 0x00babe, name: str = None) -> str:
         """
         Add a graph to the visualizer.
@@ -359,7 +363,8 @@ class pytri:
         Arguments:
             data (networkx.Graph)
             radius (float | list)
-            node_color (float | list)
+            ind_node_color (dict | {note_category: {value: color}})
+            all_node_color (float | list)
             link_color (float | list)
             name (str)
 
@@ -367,14 +372,16 @@ class pytri:
             str: name of the layer
 
         """
+        from PIL import Image
         if isinstance(data, nx.Graph):
             data = json_graph.node_link_data(data)
+        _js = self._fetch_layer_file("ColorGraphLayer.js")
 
-        _js = self._fetch_layer_file("GraphLayer.js")
         return self.add_layer(_js, {
             "graph": data,
             "radius": radius,
-            "nodeColor": node_color,
+            "allNodeColor": all_node_color,
+            "nodeColors": ind_node_color,
             "linkColor": link_color,
         }, name=name)
 

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -350,9 +350,8 @@ class pytri:
             "colors": c
         }, name=name)
 
-    def graph(self, data, radius: Union[float, Sequence[float]] = 20,
-              nc: dict = None,
-              all_nc: Union[float, Sequence[float]] = 0xbabe00,
+    def graph(self, data, radius: Union[float, Sequence[float]] = 0.15,
+              node_color: Union[float, Sequence[float]] = 0xbabe00,
               link_color: Union[float, Sequence[float]] = 0x00babe, name: str = None) -> str:
         """
         Add a graph to the visualizer.
@@ -360,8 +359,7 @@ class pytri:
         Arguments:
             data (networkx.Graph)
             radius (float | list)
-            nc (dict | {note_category: {value: color}})
-            all_nc (float | list)
+            node_color (float | list)
             link_color (float | list)
             name (str)
 
@@ -373,11 +371,12 @@ class pytri:
             data = json_graph.node_link_data(data)
         _js = self._fetch_layer_file("ColorGraphLayer.js")
 
+        mult_radius = radius * 100
+
         return self.add_layer(_js, {
             "graph": data,
-            "radius": radius,
-            "allNodeColor": all_nc,
-            "nodeColors": nc,
+            "radius": mult_radius,
+            "nodeColor": node_color,
             "linkColor": link_color,
         }, name=name)
 

--- a/pytri/js/ColorGraphLayer.js
+++ b/pytri/js/ColorGraphLayer.js
@@ -61,7 +61,6 @@ class ColorGraphLayer extends Layer {
         let xPos = nodeData.x - this.xSubtract
         let yPos = nodeData.y - this.ySubtract
         let zPos = nodeData.z - this.zSubtract
-        console.log(nodeData)
 
         xPos = -20 * (xPos - this.minX) / (this.maxX - this.minX) + -10
         yPos = -20 * (yPos - this.minY) / (this.maxY - this.minY) + -10
@@ -117,7 +116,6 @@ class ColorGraphLayer extends Layer {
             let color = this.allNodeColor
             this.graph.nodes.forEach((node, i) => {
                 let pos = this._scaledPos(this._getNodePosition(node))
-                console.log(pos)
                 particleSystem.spawnParticle({
                     position: pos,
                     size: this.radius,

--- a/pytri/js/ColorGraphLayer.js
+++ b/pytri/js/ColorGraphLayer.js
@@ -1,0 +1,153 @@
+class ColorGraphLayer extends Layer {
+    constructor(opts) {
+        super(opts);
+        this.graph = {
+            nodes: opts.graph.nodes,
+            edges: opts.graph.links,
+        };
+
+        this.nodeColors = opts.nodeColors;
+        this.radius = opts.radius;
+
+        this.allNodeColor = opts.allNodeColor || 0xbabe00;
+        this.linkColor = opts.linkColor || 0x00babe;
+        
+        if (Array.isArray(opts.minMaxVals)) {
+            this.minMaxVals = opts.minMaxVals;
+            this._calculateShift(this.minMaxVals);
+        }
+    }
+
+    _getNodePosition(node) {
+        let pos = {};
+        if ('pos' in node) {
+            if (Array.isArray(node.pos)) {
+                pos = {
+                    x: node.pos[0],
+                    y: node.pos[1],
+                    z: node.pos[2]
+                };
+            } else {
+                pos = node.pos;
+            }
+        } else if ('x' in node && 'y' in node && 'z' in node) {
+            pos = {
+                x: node.x,
+                y: node.y,
+                z: node.z
+            };
+        }
+        if (typeof pos.x != 'number' || typeof pos.y != 'number' || typeof pos.z != 'number') {
+            throw Error('missing coordinates in node');
+        }
+
+        return pos;
+    }
+
+    _calculateShift(vals) {
+        this.maxX = vals[0];
+        this.minX = vals[1];
+        this.maxY = vals[2];
+        this.minY = vals[3];
+        this.maxZ = vals[4];
+        this.minZ = vals[5];
+
+        this.xSubtract = this.minX + ((this.maxX - this.minX) / 2.0);
+        this.ySubtract = this.minY + ((this.maxY - this.minY) / 2.0);
+        this.zSubtract = this.minZ + ((this.maxZ - this.minZ) / 2.0);
+    }
+
+    _scaledPos(nodeData) {
+        let xPos = nodeData.x - this.xSubtract
+        let yPos = nodeData.y - this.ySubtract
+        let zPos = nodeData.z - this.zSubtract
+        console.log(nodeData)
+
+        xPos = -20 * (xPos - this.minX) / (this.maxX - this.minX) + -10
+        yPos = -20 * (yPos - this.minY) / (this.maxY - this.minY) + -10
+        zPos = -20 * (zPos - this.minZ) / (this.maxZ - this.minZ) + -10
+        return { x: xPos, y: yPos, z: zPos };
+    }
+    
+    requestInit(scene) {
+        let self = this;
+        let graph = {
+            nodes: this.graph.nodes,
+            edges: this.graph.edges,
+        };
+        window.graph = this.graph;
+
+        let particleSystem = new window.THREE.GPUParticleSystem({
+            maxParticles: graph.nodes.length
+        });
+
+        this.pSys = particleSystem;
+        scene.add(particleSystem);
+
+        if (!this.minMaxVals) { // Lazyily calculate minMaxVals if not passed as an argument.
+            let [ minX, minY, minZ ] = [ Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE ];
+            let [ maxX, maxY, maxZ ] = [ Number.MIN_VALUE, Number.MIN_VALUE, Number.MIN_VALUE ];
+            for (let node of this.graph.nodes) {
+                let pos = this._getNodePosition(node);
+                if (pos.x < minX) minX = pos.x;
+                if (pos.x > maxX) maxX = pos.x;
+                if (pos.y < minY) minY = pos.y;
+                if (pos.y > maxY) maxY = pos.y;
+                if (pos.z < minZ) minZ = pos.z;
+                if (pos.z > maxZ) maxZ = pos.z;
+            }
+            this._calculateShift([ maxX, minX, maxY, minY, maxZ, minZ ]);
+        }
+
+        let color = this.allNodeColor
+        if (this.nodeColors) {
+            this.graph.nodes.forEach((node, i) => {
+                let pos = this._scaledPos(this._getNodePosition(node))
+                let currNote = node['notes']
+                let firstKey = Object.keys(this.nodeColors)[0]
+                color = this.nodeColors[firstKey][currNote[firstKey]]
+                particleSystem.spawnParticle({
+                    position: pos,
+                    size: this.radius,
+                    color: color
+                });
+            })
+                
+        } else {
+            let color = this.allNodeColor
+            this.graph.nodes.forEach((node, i) => {
+                let pos = this._scaledPos(this._getNodePosition(node))
+                console.log(pos)
+                particleSystem.spawnParticle({
+                    position: pos,
+                    size: this.radius,
+                    color: color
+                });
+            })
+        }
+        self.children.push(particleSystem)
+
+        let edgeGeometry = new THREE.Geometry();
+        this.graph.edges.forEach(edge => {
+            let start = graph.nodes[edge["source"]];
+            let startPos = this._scaledPos(this._getNodePosition(start))
+            let stop = graph.nodes[edge["target"]];
+            let stopPos = this._scaledPos(this._getNodePosition(stop))
+            edgeGeometry.vertices.push(
+                new THREE.Vector3(startPos.x, startPos.y, startPos.z)
+            );
+            edgeGeometry.vertices.push(
+                new THREE.Vector3(stopPos.x, stopPos.y, stopPos.z)
+            );   
+                
+        });
+        let edges = new THREE.LineSegments(
+            edgeGeometry,
+            new THREE.LineBasicMaterial({
+                color: 0x00babe,
+            })
+        );
+        self.children.push(edges);
+        scene.add(edges);     
+    }
+}

--- a/pytri/js/ColorGraphLayer.js
+++ b/pytri/js/ColorGraphLayer.js
@@ -6,10 +6,10 @@ class ColorGraphLayer extends Layer {
             edges: opts.graph.links,
         };
 
-        this.nodeColor = opts.nodeColor || 0xbabe00;
+        this.nodeColor = opts.nodeColor;
         this.radius = opts.radius;
-;
-        this.linkColor = opts.linkColor || 0x00babe;
+
+        this.linkColor = opts.linkColor;
         
         if (Array.isArray(opts.minMaxVals)) {
             this.minMaxVals = opts.minMaxVals;
@@ -134,19 +134,14 @@ class ColorGraphLayer extends Layer {
             );
             edgeGeometry.vertices.push(
                 new THREE.Vector3(stopPos.x, stopPos.y, stopPos.z)
-            );
-            edgeGeometry.colors.push(
-                [new THREE.Color(this.linkColor), new THREE.Color(this.linkColor)]
-            )
-
-                
+            );  
         });
 
 
         let edges = new THREE.LineSegments(
             edgeGeometry,
             new THREE.LineBasicMaterial({
-                color: 0x00babe,
+                color: this.linkColor,
             })
         );
         self.children.push(edges);

--- a/pytri/js/ColorGraphLayer.js
+++ b/pytri/js/ColorGraphLayer.js
@@ -6,10 +6,9 @@ class ColorGraphLayer extends Layer {
             edges: opts.graph.links,
         };
 
-        this.nodeColors = opts.nodeColors;
+        this.nodeColor = opts.nodeColor || 0xbabe00;
         this.radius = opts.radius;
-
-        this.allNodeColor = opts.allNodeColor || 0xbabe00;
+;
         this.linkColor = opts.linkColor || 0x00babe;
         
         if (Array.isArray(opts.minMaxVals)) {
@@ -98,22 +97,18 @@ class ColorGraphLayer extends Layer {
             this._calculateShift([ maxX, minX, maxY, minY, maxZ, minZ ]);
         }
 
-        let color = this.allNodeColor
-        if (this.nodeColors) {
+        if(this.nodeColor.constructor === Array) {
             this.graph.nodes.forEach((node, i) => {
                 let pos = this._scaledPos(this._getNodePosition(node))
-                let currNote = node['notes']
-                let firstKey = Object.keys(this.nodeColors)[0]
-                color = this.nodeColors[firstKey][currNote[firstKey]]
+                let color = this.nodeColor[i]
                 particleSystem.spawnParticle({
                     position: pos,
                     size: this.radius,
                     color: color
                 });
             })
-                
         } else {
-            let color = this.allNodeColor
+            let color = this.nodeColor
             this.graph.nodes.forEach((node, i) => {
                 let pos = this._scaledPos(this._getNodePosition(node))
                 particleSystem.spawnParticle({
@@ -121,12 +116,15 @@ class ColorGraphLayer extends Layer {
                     size: this.radius,
                     color: color
                 });
-            })
+            });
         }
         self.children.push(particleSystem)
 
         let edgeGeometry = new THREE.Geometry();
-        this.graph.edges.forEach(edge => {
+
+
+
+        this.graph.edges.forEach((edge, i) => {
             let start = graph.nodes[edge["source"]];
             let startPos = this._scaledPos(this._getNodePosition(start))
             let stop = graph.nodes[edge["target"]];
@@ -136,9 +134,15 @@ class ColorGraphLayer extends Layer {
             );
             edgeGeometry.vertices.push(
                 new THREE.Vector3(stopPos.x, stopPos.y, stopPos.z)
-            );   
+            );
+            edgeGeometry.colors.push(
+                [new THREE.Color(this.linkColor), new THREE.Color(this.linkColor)]
+            )
+
                 
         });
+
+
         let edges = new THREE.LineSegments(
             edgeGeometry,
             new THREE.LineBasicMaterial({

--- a/pytri/js/GPUParticleSystem.js
+++ b/pytri/js/GPUParticleSystem.js
@@ -6,6 +6,8 @@
  *
  * Modification by j6m8: Stable color and position, for data-sensitive tasks.
  * Modification by hpcowley: Using PointsMaterial, for use with Pytri offline. 
+ * Modification by hpcowley: Use shaders from https://github.com/skeeto/webgl-particles
+ * 
  *
  * A simple to use, general purpose GPU system. Particles are spawn-and-forget with
  * several options available, and do not require monitoring or cleanup after spawning.
@@ -48,116 +50,41 @@ THREE.GPUParticleSystem = function( options ) {
 
 		vertexShader: [
 
-			'uniform float uTime;',
-			'uniform float uScale;',
-			'uniform sampler2D tNoise;',
+			'#ifdef GL_ES',
+			'precision highp float;',
+			'#endif',
 
+			'attribute vec2 index;',
 			'attribute vec3 positionStart;',
-			'attribute float startTime;',
-			'attribute vec3 velocity;',
-			'attribute float turbulence;',
+			'varying vec4 vColor;',
 			'attribute vec3 color;',
 			'attribute float size;',
-			'attribute float lifeTime;',
 
-			'varying vec4 vColor;',
-			'varying float lifeLeft;',
 
 			'void main() {',
-
-			// unpack things from our attributes'
-
-			'	vColor = vec4( color, 1.0 );',
-
-			// convert our velocity back into a value we can use'
-
-			'	vec3 newPosition;',
-			'	vec3 v;',
-
-			'	float timeElapsed = uTime - startTime;',
-
-			'	lifeLeft = 1.0 - ( timeElapsed / lifeTime );',
-
-			'	gl_PointSize = ( uScale * size ) * lifeLeft;',
-
-			'	v.x = ( velocity.x - 0.5 ) * 3.0;',
-			'	v.y = ( velocity.y - 0.5 ) * 3.0;',
-			'	v.z = ( velocity.z - 0.5 ) * 3.0;',
-
-			'	newPosition = positionStart + ( v * 10.0 ) * timeElapsed;',
-
-			'	vec3 noise = texture2D( tNoise, vec2( newPosition.x * 0.015 + ( uTime * 0.05 ), newPosition.y * 0.02 + ( uTime * 0.015 ) ) ).rgb;',
-			'	vec3 noiseVel = ( noise.rgb - 0.5 ) * 30.0;',
-
-			'	newPosition = mix( newPosition, newPosition + vec3( noiseVel * ( turbulence * 5.0 ) ), ( timeElapsed / lifeTime ) );',
-
-			'	if( v.y > 0. && v.y < .05 ) {',
-
-			'		lifeLeft = 0.0;',
-
-			'	}',
-
-			'	if( v.x < - 1.45 ) {',
-
-			'		lifeLeft = 0.0;',
-
-			'	}',
-
-			'	if( timeElapsed > 0.0 ) {',
-
-			'		gl_Position = projectionMatrix * modelViewMatrix * vec4( newPosition, 1.0 );',
-
-			'	} else {',
-
-			'		gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
-			'		lifeLeft = 0.0;',
-			'		gl_PointSize = 0.;',
-
-			'	}',
-
+				'gl_PointSize = size;',
+				'vColor = vec4( color, 1.0 );',
+				'gl_Position = projectionMatrix * modelViewMatrix * vec4( positionStart, 1.0 );',
 			'}'
-
-		].join( '\n' ),
+		].join('\n'),
 
 		fragmentShader: [
-
-			'float scaleLinear( float value, vec2 valueDomain ) {',
-
-			'	return ( value - valueDomain.x ) / ( valueDomain.y - valueDomain.x );',
-
-			'}',
-
-			'float scaleLinear( float value, vec2 valueDomain, vec2 valueRange ) {',
-
-			'	return mix( valueRange.x, valueRange.y, scaleLinear( value, valueDomain ) );',
-
-			'}',
+			'#ifdef GL_ES',
+			'precision highp float;',
+			'#endif',
 
 			'varying vec4 vColor;',
-			'varying float lifeLeft;',
-
-			'uniform sampler2D tSprite;',
 
 			'void main() {',
-
-			'	float alpha = 0.;',
-
-			'	if( lifeLeft > 0.995 ) {',
-
-			'		alpha = scaleLinear( lifeLeft, vec2( 1.0, 0.995 ), vec2( 0.0, 1.0 ) );',
-
-			'	} else {',
-
-			'		alpha = lifeLeft * 0.75;',
-
-			'	}',
-
-			'	vec4 tex = texture2D( tSprite, gl_PointCoord );',
-			'	gl_FragColor = vec4( vColor.rgb * tex.a, alpha * tex.a );',
-
+				'vec2 p = 2.0 * (gl_PointCoord - 0.5);',
+				'if (length(p) < 1.0) {',
+					'vec2 norm = normalize(p * vec2(1, -1));',
+					'gl_FragColor = vec4( vColor.rgb, 1.0);',
+				'} else {',
+					'discard;',
+				'}',
 			'}'
-
-		].join( '\n' )
+		].join('\n')
 
 	};
 
@@ -177,13 +104,6 @@ THREE.GPUParticleSystem = function( options ) {
 
 	};
 
-	// var textureLoader = new THREE.TextureLoader();
-
-	// this.particleNoiseTex = this.PARTICLE_NOISE_TEXTURE || textureLoader.load( 'perlin-512.png' );
-	// this.particleNoiseTex.wrapS = this.particleNoiseTex.wrapT = THREE.RepeatWrapping;
-
-	// this.particleSpriteTex = this.PARTICLE_SPRITE_TEXTURE || textureLoader.load( 'glow.png' );
-	// this.particleSpriteTex.wrapS = this.particleSpriteTex.wrapT = THREE.RepeatWrapping;
 
 	this.particleShaderMat = new THREE.ShaderMaterial( {
 		transparent: true,


### PR DESCRIPTION
Integrated the large graph and node coloring capabilities of EDGE into Pytri.

- `graph` uses a GPU particle system for nodes
- Deleted `large_graph`, as now `graph` and `large_graph` do essentially the same thing
- Made changes to `GPUParticleSystem.js`, including adding a custom shader (as opposed to loading in texture from file, since that doesn't play nice with Jupyter)
~- Added capability to color nodes in the graph according to attributes passed by user (ie: each node of the graph has a `notes` key as an attribute: `notes: {'clique': 1}`. User passes a coloring key to the `graph` method to specify how to color code: `{'clique': {1: 0xffffff, 2: 0xbbbbbb}}`. Can also specify that all nodes of a given graph be a particular color, passed into function call.~