### PR TITLE
Fix incompatibility with networkx 2.*

### DIFF
--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -459,6 +459,8 @@ class pytri:
             data = json_graph.node_link_data(data)
         _js = self._fetch_layer_file("GraphLayer.js")
 
+        node_dict = {n['id']: {'pos': n} for n in data['nodes']}
+
         PARTICLE_RADIUS_SCALE = 50
         mult_radius: Union[float, List[float]]
         if isinstance(radius, (float, int)):
@@ -473,6 +475,7 @@ class pytri:
                 mult_radius = [r * PARTICLE_RADIUS_SCALE for r in radius]
 
         return self.add_layer(_js, {
+            "nodeDict": node_dict,
             "graph": data,
             "radius": mult_radius,
             "nodeColor": node_color,

--- a/pytri/__init__.py
+++ b/pytri/__init__.py
@@ -459,7 +459,7 @@ class pytri:
             data = json_graph.node_link_data(data)
         _js = self._fetch_layer_file("GraphLayer.js")
 
-        node_dict = {n['id']: {'pos': n} for n in data['nodes']}
+        node_dict = {n['id']: n for n in data['nodes']}
 
         PARTICLE_RADIUS_SCALE = 50
         mult_radius: Union[float, List[float]]

--- a/pytri/js/GraphLayer.js
+++ b/pytri/js/GraphLayer.js
@@ -32,10 +32,7 @@ class ColorGraphLayer extends window.substrate.Layer {
                 z: node.z
             };
         }
-        if (typeof pos.x != 'number' || typeof pos.y != 'number' || typeof pos.z != 'number') {
-            throw Error('missing coordinates in node');
-        }
-
+        // TODO: add error handling for no position in node
         return pos;
     }
 

--- a/pytri/js/GraphLayer.js
+++ b/pytri/js/GraphLayer.js
@@ -53,7 +53,6 @@ class ColorGraphLayer extends window.substrate.Layer {
 
         this.pSys = particleSystem;
         scene.add(particleSystem);
-        window.graph = this.graph;
         if(this.meshNodes) {
             this.graph.nodes.forEach((node, i) => {
                 let sph = new window.THREE.Mesh(

--- a/pytri/js/GraphLayer.js
+++ b/pytri/js/GraphLayer.js
@@ -5,7 +5,7 @@ class ColorGraphLayer extends window.substrate.Layer {
             nodes: opts.graph.nodes,
             edges: opts.graph.links,
         };
-
+        this.nodeDict = opts.nodeDict;
         this.nodeColor = opts.nodeColor;
         this.radius = opts.radius;
 
@@ -15,7 +15,7 @@ class ColorGraphLayer extends window.substrate.Layer {
 
     _getNodePosition(node) {
         let pos = {};
-        if ('pos' in node) {
+        if (node.hasOwnProperty('pos')) {
             if (Array.isArray(node.pos)) {
                 pos = {
                     x: node.pos[0],
@@ -54,7 +54,7 @@ class ColorGraphLayer extends window.substrate.Layer {
 
         this.pSys = particleSystem;
         scene.add(particleSystem);
-
+        window.graph = this.graph;
         if(this.meshNodes) {
             this.graph.nodes.forEach((node, i) => {
                 let sph = new window.THREE.Mesh(
@@ -71,6 +71,7 @@ class ColorGraphLayer extends window.substrate.Layer {
                 scene.add(sph);
             });
         } else {
+            
             if(this.nodeColor.constructor === Array) {
                 this.graph.nodes.forEach((node, i) => {
                     let pos = this._getNodePosition(node);
@@ -97,10 +98,10 @@ class ColorGraphLayer extends window.substrate.Layer {
 
         let edgeGeometry = new THREE.Geometry();
 
-        this.graph.edges.forEach((edge, i) => {
-            let start = graph.nodes[edge["source"]];
+        this.graph.edges.forEach(edge => {
+            let start = this.nodeDict[edge["source"]];
             let startPos = this._getNodePosition(start);
-            let stop = graph.nodes[edge["target"]];
+            let stop = this.nodeDict[edge["target"]];
             let stopPos = this._getNodePosition(stop);
             edgeGeometry.vertices.push(
                 new THREE.Vector3(startPos.x, startPos.y, startPos.z)

--- a/pytri/js/GraphLayer.js
+++ b/pytri/js/GraphLayer.js
@@ -46,7 +46,6 @@ class ColorGraphLayer extends window.substrate.Layer {
             nodes: this.graph.nodes,
             edges: this.graph.edges,
         };
-        window.graph = this.graph;
 
         let particleSystem = new window.THREE.GPUParticleSystem({
             maxParticles: graph.nodes.length


### PR DESCRIPTION
This bug was a result of a breaking change in Networkx `json_graph.node_link_data()`. Prior to version 2.0, this returned nodes as a dictionary. In versions >=2.0, nodes are returned as a list.

Note that any graphs created using Networkx <2.0 that were pickled don't seem to work. Users should re-generate their pickled graph using Networkx >= 2.0 for now. I'm happy to add support for earlier Networkx later.