### PR TITLE
Setting color and radius of nodes, refactor of GraphLayer

### DIFF
--- a/pytri/js/GraphLayer.js
+++ b/pytri/js/GraphLayer.js
@@ -39,19 +39,9 @@ class ColorGraphLayer extends window.substrate.Layer {
 
     requestInit(scene) {
         let self = this;
-        let graph = {
-            nodes: this.graph.nodes,
-            edges: this.graph.edges,
-        };
 
-        let particleSystem = new window.THREE.GPUParticleSystem({
-            maxParticles: graph.nodes.length
-        });
-
-        this.pSys = particleSystem;
-        scene.add(particleSystem);
         if(this.meshNodes) {
-            this.graph.nodes.forEach((node, i) => {
+            self.graph.nodes.forEach((node, i) => {
                 let sph = new window.THREE.Mesh(
                     new window.THREE.SphereGeometry(
                         Array.isArray(this.nodeSize) ? this.nodeSize[i] : this.nodeSize, 6, 6
@@ -60,13 +50,21 @@ class ColorGraphLayer extends window.substrate.Layer {
                         color: Array.isArray(this.nodeColor) ? this.nodeColor[i] : this.nodeColor
                     })
                 );
+
                 let pos = this._getNodePosition(node);
                 sph.position.set(pos.x, pos.y, pos.z);
+
                 this.children.push(sph);
                 scene.add(sph);
             });
         } else {
-            this.graph.nodes.forEach((node, i) => {
+            let particleSystem = new window.THREE.GPUParticleSystem({
+                maxParticles: self.graph.nodes.length
+            });
+
+            scene.add(particleSystem);
+
+            self.graph.nodes.forEach((node, i) => {
                 let pos = this._getNodePosition(node);
                 particleSystem.spawnParticle({
                     position: pos,
@@ -78,7 +76,7 @@ class ColorGraphLayer extends window.substrate.Layer {
         }
 
         let edgeGeometry = new THREE.Geometry();
-        this.graph.edges.forEach(edge => {
+        self.graph.edges.forEach(edge => {
             let start = this.nodeDict[edge["source"]];
             let startPos = this._getNodePosition(start);
             let stop = this.nodeDict[edge["target"]];

--- a/pytri/js/GraphLayer.js
+++ b/pytri/js/GraphLayer.js
@@ -1,4 +1,4 @@
-class ColorGraphLayer extends window.substrate.Layer {
+class GraphLayer extends window.substrate.Layer {
     constructor(opts) {
         super(opts);
         this.graph = {

--- a/pytri/js/GraphLayer.js
+++ b/pytri/js/GraphLayer.js
@@ -7,7 +7,7 @@ class ColorGraphLayer extends window.substrate.Layer {
         };
         this.nodeDict = opts.nodeDict;
         this.nodeColor = opts.nodeColor;
-        this.radius = opts.radius;
+        this.nodeSize = opts.radius;
 
         this.linkColor = opts.linkColor;
         this.meshNodes = opts.meshNodes;
@@ -54,10 +54,10 @@ class ColorGraphLayer extends window.substrate.Layer {
             this.graph.nodes.forEach((node, i) => {
                 let sph = new window.THREE.Mesh(
                     new window.THREE.SphereGeometry(
-                        this.nodeSizeIsArray ? this.nodeSize[i] : this.nodeSize, 6, 6
+                        Array.isArray(this.nodeSize) ? this.nodeSize[i] : this.nodeSize, 6, 6
                     ),
                     new window.THREE.MeshBasicMaterial({
-                        color: this.nodeColorIsArray ? this.nodeColor[i] : this.nodeColor
+                        color: Array.isArray(this.nodeColor) ? this.nodeColor[i] : this.nodeColor
                     })
                 );
                 let pos = this._getNodePosition(node);
@@ -66,33 +66,18 @@ class ColorGraphLayer extends window.substrate.Layer {
                 scene.add(sph);
             });
         } else {
-            
-            if(this.nodeColor.constructor === Array) {
-                this.graph.nodes.forEach((node, i) => {
-                    let pos = this._getNodePosition(node);
-                    let color = this.nodeColor[i];
-                    particleSystem.spawnParticle({
-                        position: pos,
-                        size: this.nodeSize,
-                        color: color
-                    });
+            this.graph.nodes.forEach((node, i) => {
+                let pos = this._getNodePosition(node);
+                particleSystem.spawnParticle({
+                    position: pos,
+                    size: Array.isArray(this.nodeSize) ? this.nodeSize[i] : this.nodeSize,
+                    color: Array.isArray(this.nodeColor) ? this.nodeColor[i] : this.nodeColor
                 });
-            } else {
-                let color = this.nodeColor;
-                this.graph.nodes.forEach((node, i) => {
-                    let pos = this._getNodePosition(node);
-                    particleSystem.spawnParticle({
-                        position: pos,
-                        size: this.nodeSize,
-                        color: color
-                    });
-                });
-            }
+            });
             self.children.push(particleSystem);
         }
 
         let edgeGeometry = new THREE.Geometry();
-
         this.graph.edges.forEach(edge => {
             let start = this.nodeDict[edge["source"]];
             let startPos = this._getNodePosition(start);


### PR DESCRIPTION
Fixes #95 
- Setting radius of meshed or particle system nodes as either a list or single value
- Setting color of meshed or particle system nodes as either a list or single value

Fixes #94 
- Rename `ColorGraphLayer` to `GraphLayer`

Adds:
- Refactor GraphLayer for clarity, remove unused variables from previous iterations of GraphLayer
- Refactor GraphLayer for greater memory efficiency: don't add particle system to scene if `mesh_nodes=True`


