### PR TITLE
Fix race condition in ImageLayer

### DIFF
--- a/pytri/js/ImageLayer.js
+++ b/pytri/js/ImageLayer.js
@@ -12,7 +12,7 @@ class ImageLayer extends window.substrate.Layer {
         let self = this;
         self.needsUpdate = true;
 
-        let geometry = new window.THREE.PlaneBufferGeometry(self.width, self.height);
+        let geometry = new window.THREE.PlaneGeometry(self.width, self.height);
         let image = new Image();
         image.src = self.dataURI;
         let texture = new window.THREE.Texture(image);


### PR DESCRIPTION
Switch from `PlaneBufferGeometry` to `PlaneGeometry` in ImageLayer. This corrects an issue in multi-image views where the very first is loaded as a non-textured triangle with a default size and orientation. This seems to be caused by a race condition, but it appears that `PlaneGeometry` is not affected.